### PR TITLE
readme updated to include version-string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,18 +22,28 @@ $ npm install --save-dev grunt-electron
 require('load-grunt-tasks')(grunt); // npm install --save-dev load-grunt-tasks
 
 grunt.initConfig({
-	electron: {
-		osxBuild: {
-			options: {
-				name: 'Fixture',
-				dir: 'app',
-				out: 'dist',
-				version: '0.25.3',
-				platform: 'darwin',
-				arch: 'x64'
-			}
-		}
-	}
+    electron: {
+        osxBuild: {
+            options: {
+                name: 'Fixture',
+                dir: 'app',
+                out: 'dist',
+                version: '0.25.3',
+                platform: 'darwin',
+                arch: 'x64',
+                'version-string': {  // windows only
+                  CompanyName: 'Acme',
+                  LegalCopyright: 'Copyright 2015 Acme. All rights reserved.',
+                  FileDescription : 'App description',
+                  OriginalFilename : 'App name.exe',
+                  FileVersion : '0.0.1',
+                  ProductVersion : '0.0.1',
+                  ProductName : 'App name',
+                  InternalName : 'App name.exe'
+                }
+            }
+        }
+    }
 });
 
 grunt.registerTask('default', ['electron']);


### PR DESCRIPTION
This is companion PR to the `Version info added to the final executable using rcedit` https://github.com/maxogden/electron-packager/pull/63 for the issue `Set product name, file description copyright on Windows` https://github.com/maxogden/electron-packager/issues/30

Readme updated to reflect the `version-string`  info on the grunt config. Merge this once the source pr is accepted.
