### PR TITLE
log error and abort task

### DIFF
--- a/tasks/electron.js
+++ b/tasks/electron.js
@@ -3,6 +3,13 @@ var electronPackager = require('electron-packager');
 
 module.exports = function (grunt) {
 	grunt.registerMultiTask('electron', 'Package Electron apps', function () {
-		electronPackager(this.options(), this.async());
+		var done = this.async();
+		electronPackager(this.options(), function (error) {
+			if (error) {
+				grunt.warn(error);
+			} else {
+				done();
+			}
+		});
 	});
 };


### PR DESCRIPTION
First off all i'm sorry to destroy your lean approach, but i realized that a lot errors inside electron packager   are just passed to the callback of the electronPackager function. So even if there was an error during the build process grunt-electron would just pass without any logs or errors. So i added this check to log the error message and abort the task.
