### PR TITLE
:arrow_up: electron-packager 5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "apps"
   ],
   "dependencies": {
-    "electron-packager": "^5.1.0"
+    "electron-packager": "^5.2.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
5.2.1 includes a fix for https://github.com/maxogden/electron-packager/issues/219, which would allow us to switch back to the canonical forks of grunt-electron & others. :star2: 
