### PR TITLE
Update to electron-packager 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "apps"
   ],
   "dependencies": {
-    "electron-packager": "^5.1.0"
+    "electron-packager": "^6.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Electron changed dependencies e.g. the icon file is now for OSX electron.icns (before atom.icns). electron-packager 6.0.0 is required now.
