### PR TITLE
Bump electron-packager to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "apps"
   ],
   "dependencies": {
-    "electron-packager": "^6.0.0"
+    "electron-packager": "^6.0.2"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Now the remaining issue with the icon is fixed in 6.0.2 (Electron changed dependencies e.g. the icon file is now for OSX electron.icns (before atom.icns)
