### PR TITLE
upgrade electron-packager to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "apps"
   ],
   "dependencies": {
-    "electron-packager": "^6.0.0"
+    "electron-packager": "^7.0.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Electron-packager versions prior to 7.0.0 have a critical security issue (electron-userland/electron-packager#333) where SSL certificates aren't validated by default.
