### PR TITLE
Use the Promise API of Electron Packager

### DIFF
--- a/tasks/electron.js
+++ b/tasks/electron.js
@@ -5,14 +5,11 @@ module.exports = grunt => {
 	grunt.registerMultiTask('electron', 'Package Electron apps', function () {
 		const done = this.async();
 
-		electronPackager(this.options(), err => {
-			if (err) {
+		electronPackager(this.options())
+			.then(() => done())
+			.catch(err => {
 				grunt.warn(err);
 				done();
-				return;
-			}
-
-			done();
-		});
+			});
 	});
 };


### PR DESCRIPTION
I'm going to deprecate the callback API for Electron Packager soon (because folks can just use `nodeify` if they need/like that style), so `grunt-electron` should use the Promise API instead.